### PR TITLE
Improve type annotations and propose some fixes

### DIFF
--- a/registry.py
+++ b/registry.py
@@ -4,7 +4,7 @@ import functools
 import inspect
 import sys
 from dataclasses import dataclass
-from typing import Any, Callable, cast, Dict, Generic, Optional, TypeVar
+from typing import Any, Callable, cast, Dict, Generic, TypeVar
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec
@@ -19,8 +19,8 @@ P = ParamSpec("P")
 class RegistryInstance(Generic[T]):
     """Store an instance of an object and a shutdown hook."""
 
-    shutdown_callback: Optional[Callable[[T], Any]] = None
-    obj: Optional[T] = None
+    shutdown_callback: Callable[[T], Any] | None = None
+    obj: T | None = None
     arg_hash: int = 0
 
     def shutdown(self) -> None:
@@ -47,7 +47,7 @@ class RegistrySingleton:
     """
 
     _registry: Dict[Callable[..., Any], RegistryInstance[Any]]
-    _active: Optional[Callable[..., Any]]
+    _active: Callable[..., Any] | None
 
     def __new__(cls):
         """Create a singleton instance of the registry."""

--- a/test_registry.py
+++ b/test_registry.py
@@ -39,6 +39,11 @@ def test_register():
     # Instantiate the singleton
     obj = registry.get(MyFirstClass, 1)
     obj_id = id(obj)
+    # Hold a reference to this object until the end of the test because
+    # id() is based on the memory location of the object and we don't want
+    # another object to be allocated the same memory address once this one
+    # is garbage collected.
+    _obj_id_ref = obj
     assert obj.x == 1
     assert first_constructor_calls == 1
     assert first_shutdown_calls == 0
@@ -161,6 +166,11 @@ def test_registry_class_decorator():
     # Instantiate the singleton
     obj = MyFirstClass(1)
     obj_id = id(obj)
+    # Hold a reference to this object until the end of the test because
+    # id() is based on the memory location of the object and we don't want
+    # another object to be allocated the same memory address once this one
+    # is garbage collected.
+    _obj_id_ref = obj
     assert obj.x == 1
     assert first_constructor_calls == 1
     assert first_shutdown_calls == 0


### PR DESCRIPTION
## Changes

This PR improves the type annotations in `registry.py` and proposes some fixes for other things that I've found.

I've broken up the changes into distinct commits and included detailed commit messages to explain motivation and reasonings behind the changes.

`typing_extensions` is now a required dependency because `ParamSpec` is not available all the way back to Python 3.7. This shouldn't really be a problem though, most type annotated packages require `typing_extensions`.

## Testing

I've type checked with mypy on Python 3.7, 3.7, and 3.10, and I've run the tests successfully on those same Python versions.

I assume that if mypy can infer all the types correctly now, that intellisense can as well but let me know if this isn't the case.

## Other

You'll see that the one mypy error I could not resolve is related to the creation of `SingletonWrapper` using base classes that are variables. I left a comment in the commit message that I'd fix it in a latter commit, but I don't think it can be reconciled so I've had to tell mypy to ignore that.

The code works so whether or not you refactor this really comes down to how strictly typed you want this to be. Mypy cannot use `SingletonWrapper` for static analysis because its base class is dynamic. An alternative would be to use a singleton function rather than class similar to this solution https://stackoverflow.com/a/70702306.